### PR TITLE
(0.20.0) Set environment variable MALLOCOPTIONS=multiheap on AIX

### DIFF
--- a/src/java.base/unix/native/libjli/java_md_solinux.c
+++ b/src/java.base/unix/native/libjli/java_md_solinux.c
@@ -310,9 +310,9 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 
 #ifdef AIX
     const char *mallocOptionsName = "MALLOCOPTIONS";
-    const char *mallocOptionsValue = "multiheap,buckets";
+    const char *mallocOptionsValue = "multiheap";
     if (setenv(mallocOptionsName, mallocOptionsValue, 0) != 0) {
-        fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap,buckets') failed: performance may be affected\n");
+        fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap') failed: performance may be affected\n");
     }
 #endif
 


### PR DESCRIPTION
The previous setting `MALLOCOPTIONS=multiheap,buckets` caused
Issue eclipse/openj9#8842

Cherry pick of #29 for the 0.20.0 branch.