### PR TITLE
Move message about checking for freemarker

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -373,12 +373,12 @@ AC_DEFUN([OPENJDK_VERSION_DETAILS],
 AC_DEFUN([OPENJ9_THIRD_PARTY_REQUIREMENTS],
 [
   # check 3rd party library requirement for UMA
-  AC_MSG_CHECKING([that freemarker location is set])
   AC_ARG_WITH(freemarker-jar, [AS_HELP_STRING([--with-freemarker-jar],
       [path to freemarker.jar (used to build OpenJ9 build tools)])])
 
   FREEMARKER_JAR=
   if test "x$OPENJ9_ENABLE_CMAKE" != xtrue ; then
+    AC_MSG_CHECKING([that freemarker location is set])
     if test "x$with_freemarker_jar" == x -o "x$with_freemarker_jar" == xno ; then
       AC_MSG_RESULT([no])
       printf "\n"


### PR DESCRIPTION
Move the message to inside the conditional where we actually check for
freemarker. Currently if  cmake is enabled, a message about checking
for freemarker is emitted, but no check is performed, and no response
emitted.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>