### PR TITLE
(0.21.0) Update codesign entitlements file name

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -117,7 +117,7 @@ ifeq (,$(CODESIGN))
   CodesignFile =
 else
   CodesignFile = $(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
-	--entitlements $(TOPDIR)/make/data/macosxsigning/entitlements.plist \
+	--entitlements $(TOPDIR)/make/data/macosxsigning/default.plist \
 	--options runtime \
 	--timestamp \
 	$1


### PR DESCRIPTION
It was renamed by:
* 8244951: Missing entitlements for hardened runtime

This is a replay of #66 for the 0.21.0 release branch; it assumes 8244951 will be merged into that branch first.